### PR TITLE
Fixed an error with reversing code

### DIFF
--- a/chapters/arrays/reverse/test_copy.go
+++ b/chapters/arrays/reverse/test_copy.go
@@ -4,7 +4,7 @@ import "fmt"
 
 func reverse(numbers []int) []int {
 	newNumbers := make([]int, len(numbers))
-	for i, j := 0, len(numbers)-1; i < j; i, j = i+1, j-1 {
+	for i, j := 0, len(numbers)-1; i <= j; i, j = i+1, j-1 {
 		newNumbers[i], newNumbers[j] = numbers[j], numbers[i]
 	}
 	return newNumbers


### PR DESCRIPTION
Before: Middle value was missed if array had an odd number of entries
[1, 2, 3, 4, 5] => [5, 4, 0, 2, 1]

After: Middle value is properly assigned
[1, 2, 3, 4, 5] =>[5, 4, 3, 2, 1]